### PR TITLE
AccessToken 字符串再次 JSON 编码后无法识别

### DIFF
--- a/src/im_1_0/Dingtalk.php
+++ b/src/im_1_0/Dingtalk.php
@@ -1300,7 +1300,7 @@ class Dingtalk extends OpenApiClient
             $realHeaders = $headers->commonHeaders;
         }
         if (!Utils::isUnset($headers->xAcsDingtalkAccessToken)) {
-            @$realHeaders['x-acs-dingtalk-access-token'] = Utils::toJSONString($headers->xAcsDingtalkAccessToken);
+            @$realHeaders['x-acs-dingtalk-access-token'] = $headers->xAcsDingtalkAccessToken;
         }
         $req = new OpenApiRequest([
             'headers' => $realHeaders,

--- a/src/robot_1_0/Dingtalk.php
+++ b/src/robot_1_0/Dingtalk.php
@@ -224,7 +224,7 @@ class Dingtalk extends OpenApiClient
             $realHeaders = $headers->commonHeaders;
         }
         if (!Utils::isUnset($headers->xAcsDingtalkAccessToken)) {
-            @$realHeaders['x-acs-dingtalk-access-token'] = Utils::toJSONString($headers->xAcsDingtalkAccessToken);
+            @$realHeaders['x-acs-dingtalk-access-token'] = $headers->xAcsDingtalkAccessToken;
         }
         $req = new OpenApiRequest([
             'headers' => $realHeaders,


### PR DESCRIPTION
```php
array:3 [
  "status" => 0
  "code" => "InvalidAuthentication"
  "message" => "code: 400, 不合法的access_token request id: EFCA3ED1-6893-7CAF-8C8D-A5AEC89C85FC"
]
```

去掉编码后再执行
```php
array:2 [
  "headers" => array:12 [
    "Server" => array:1 [
      0 => "DingTalk/1.0.0"
    ]
    "Date" => array:1 [
      0 => "Wed, 29 Jun 2022 12:11:13 GMT"
    ]
    "Content-Type" => array:1 [
      0 => "application/json;charset=utf-8"
    ]
    "Content-Length" => array:1 [
      0 => "121"
    ]
    "Connection" => array:1 [
      0 => "keep-alive"
    ]
    "Access-Control-Allow-Origin" => array:1 [
      0 => "*"
    ]
    "Access-Control-Allow-Methods" => array:1 [
      0 => "POST, GET, OPTIONS, PUT, DELETE"
    ]
    "Access-Control-Max-Age" => array:1 [
      0 => "172800"
    ]
    "x-acs-request-id" => array:1 [
      0 => "E0DDEAC6-B344-7EFD-A28A-002F5D68EA87"
    ]
    "x-acs-trace-id" => array:1 [
      0 => "a256909d956e020a394833a18880de5c"
    ]
    "Access-Control-Allow-Headers" => array:1 [
      0 => "X-Requested-With, X-Sequence, _aop_secret, _aop_signature, x-acs-dingtalk-access-token"
    ]
    "Content-Security-Policy-Report-Only" => array:1 [
      0 => "default-src 'self';style-src 'self' 'unsafe-inline' dev.g.alicdn.com g.alicdn.com at.alicdn.com *.test.youku.com *.taobao.net webapi.amap.com;script-src 'report-sample' 'self' 'unsafe-eval' 'unsafe-inline' *.dingtalk.com *.cnzz.com *.alicdn.com market.wapa.taobao.com g.alicdn.com dev.g.alicdn.com ynuf.alipay.com log.mmstat.com s.tbcdn.cn vip.laiwang.com wswukong.laiwang.com local.alipcsec.com:6691 *.taobao.net cfd.aliyun.com restapi.amap.com webapi.amap.com retcode.alicdn.com cfall.aliyun.com gw.alipayobjects.com ynuf.aliapp.org;connect-src 'self' *.dingtalk.com wss://*.dingtalk.com ynuf.alipay.com dev.g.alicdn.com g.alicdn.com retcode.taobao.com dingtalk-cspase-sh.oss-cn-shanghai.aliyuncs.com dingtalk-cspase-sz.oss-cn-shenzhen.aliyuncs.com arms-retcode.aliyuncs.com arms-retcode.aliyuncs.com ynuf.aliapp.org px-intl.ucweb.com px.ucweb.com gm.mmstat.com preview-lippi-space-zjk.oss-accelerate.aliyuncs.com wgo.mmstat.com wss://alidocs-body.oss-accelerate.aliyuncs.com wss://pre-collab.dingtalk.com;frame-src 'self' h5.m.taobao.com qiye.aliyun.com log.laiwang.com dev.g.alicdn.com g.alicdn.com login.dingtalk.com login2.dingtalk.com *.dingtalk.com mailsso.mxhichina.com wvjbscheme: alipaybridge: alipaymonitor: mmstat.alicdn.com res.mmstat.com ynuf.aliapp.org alidocs.oss-cn-zhangjiakou.aliyuncs.com;font-src 'self' at.alicdn.com dev.g.alicdn.com g.alicdn.com data: *.taobao.net i.alicdn.com;img-src 'self' data: http: fourier.taobao.com *.dingtalk.com *.aliimg.com *.alicdn.com *.mmstat.com ynuf.alipay.com arms-retcode.aliyuncs.com pin.aliyun.com fourier.alibaba.com retcode.taobao.com *.cnzz.com dingtalk-cspase-sh.oss-cn-shanghai.aliyuncs.com dingtalk-cspase-sz.oss-cn-shenzhen.aliyuncs.com restapi.amap.com kcart.alipay.com preview-lippi-space-zjk.oss-cn-zhangjiakou.aliyuncs.com px-intl.ucweb.com px.ucweb.com alidocs.oss-cn-zhangjiakou.aliyuncs.com;media-src 'self' *.dingtalk.com cloud.video.taobao.com videocdn.taobao.com tbm-auth.alicdn.com dev.g.alicdn.com g.alicdn.com;report-uri https://csp.dingtalk.com/csp;"
    ]
  ]
  "body" => array:3 [
    "flowControlledStaffIdList" => null
    "invalidStaffIdList" => null
    "processQueryKey" => "+n51AnA84Vf+9ayPNG3xbThV6C0RkFPv8FtIYMQuV+4="
  ]
]
```
